### PR TITLE
UPDATED aws_iam_inistance_profile

### DIFF
--- a/iamroles.tf
+++ b/iamroles.tf
@@ -17,5 +17,5 @@ resource "aws_iam_policy_attachment" "test-attach" {
 
 resource "aws_iam_instance_profile" "test_profile" {
   name  = "test_profile"
-  roles = ["${aws_iam_role.ec2_s3_access_role.name}"]
+  role = "${aws_iam_role.ec2_s3_access_role.name}"
 }


### PR DESCRIPTION
Warning: aws_iam_instance_profile.test_profile: "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile